### PR TITLE
Support Ollama API key aliases and add stratified split feasibility checks

### DIFF
--- a/src/treehouse_lab/datasets.py
+++ b/src/treehouse_lab/datasets.py
@@ -130,6 +130,12 @@ def split_dataset(bundle: DatasetBundle, config: ExperimentConfig) -> DatasetSpl
     if test_size <= 0 or validation_size <= 0 or test_size + validation_size >= 1:
         msg = "validation_size and test_size must both be positive and sum to less than 1."
         raise ValueError(msg)
+    if config.split.stratify:
+        _validate_stratified_split_feasibility(
+            bundle.target,
+            test_size=test_size,
+            validation_size=validation_size,
+        )
 
     stratify_values = bundle.target if config.split.stratify else None
     X_train_val, X_test, y_train_val, y_test = train_test_split(
@@ -163,6 +169,42 @@ def split_dataset(bundle: DatasetBundle, config: ExperimentConfig) -> DatasetSpl
         y_test=y_test.reset_index(drop=True),
         preprocessor=preprocessor,
     )
+
+
+def _validate_stratified_split_feasibility(
+    target: pd.Series,
+    *,
+    test_size: float,
+    validation_size: float,
+) -> None:
+    class_counts = target.value_counts()
+    class_distribution = {str(label): int(count) for label, count in class_counts.sort_index().items()}
+    formatted_distribution = ", ".join(f"{label}:{count}" for label, count in class_distribution.items())
+    row_index = np.arange(len(target))
+    try:
+        _, _, y_train_val, _ = train_test_split(
+            row_index,
+            target,
+            test_size=test_size,
+            random_state=0,
+            stratify=target,
+        )
+        validation_share_of_train_val = validation_size / (1 - test_size)
+        train_test_split(
+            np.arange(len(y_train_val)),
+            y_train_val,
+            test_size=validation_share_of_train_val,
+            random_state=0,
+            stratify=y_train_val,
+        )
+    except ValueError as exc:
+        msg = (
+            "Stratified split is not feasible for the requested train/validation/test fractions. "
+            f"split.test_size={test_size:.3f}, split.validation_size={validation_size:.3f}. "
+            f"Class counts: {formatted_distribution}. "
+            f"Original sklearn error: {exc}"
+        )
+        raise ValueError(msg) from exc
 
 
 def normalize_classification_target(

--- a/src/treehouse_lab/llm.py
+++ b/src/treehouse_lab/llm.py
@@ -25,6 +25,7 @@ DEFAULT_ADVISOR_PROVIDER = "ollama"
 DEFAULT_ADVISOR_QUESTION = "What should I do next and why?"
 DEFAULT_OLLAMA_MODEL = "gemma3:4b"
 DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+OLLAMA_API_KEY_ENV_VARS = ("OLLAMA_API_KEY", "OLLAMA_CLOUD_KEY", "VIOLAAMA_CLOUD_KEY")
 DEFAULT_AGENT_CLI = "codex"
 DEFAULT_OPENAI_COMPATIBLE_MODEL = "gpt-4.1-mini"
 DEFAULT_OPENAI_MODEL = "gpt-5.4-mini"
@@ -197,7 +198,10 @@ def _request_text_via_ollama(system_prompt: str, user_prompt: str, purpose: str,
                 status="unavailable",
                 provider="ollama",
                 model=model,
-                message=f"Set OLLAMA_API_KEY to use Ollama cloud directly for {purpose}, or point TREEHOUSE_LAB_OLLAMA_BASE_URL at a local Ollama host.",
+                message=(
+                    f"Set one of {', '.join(OLLAMA_API_KEY_ENV_VARS)} to use Ollama cloud directly for {purpose}, "
+                    "or point TREEHOUSE_LAB_OLLAMA_BASE_URL at a local Ollama host."
+                ),
             )
         headers["Authorization"] = f"Bearer {api_key}"
 
@@ -560,21 +564,25 @@ def _setting(name: str, project_root: str, default: str = "") -> str:
     if setting_value:
         return setting_value
 
-    env_map = {
+    env_map: dict[str, str | tuple[str, ...]] = {
         "provider": "TREEHOUSE_LAB_LLM_PROVIDER",
         "model": "TREEHOUSE_LAB_LLM_MODEL",
         "ollama_base_url": "TREEHOUSE_LAB_OLLAMA_BASE_URL",
-        "ollama_api_key": "OLLAMA_API_KEY",
+        "ollama_api_key": OLLAMA_API_KEY_ENV_VARS,
         "agent_cli": "TREEHOUSE_LAB_AGENT_CLI",
         "openai_compatible_base_url": "TREEHOUSE_LAB_OPENAI_COMPATIBLE_BASE_URL",
         "openai_compatible_api_key": "TREEHOUSE_LAB_OPENAI_COMPATIBLE_API_KEY",
         "openai_api_key": "OPENAI_API_KEY",
     }
     env_name = env_map.get(name)
-    if env_name:
+    if isinstance(env_name, tuple):
+        env_value = _resolve_first_env(env_name)
+    elif isinstance(env_name, str):
         env_value = os.getenv(env_name, "").strip()
-        if env_value:
-            return env_value
+    else:
+        env_value = ""
+    if env_value:
+        return env_value
     return default.strip()
 
 
@@ -668,3 +676,11 @@ def _is_local_base_url(base_url: str) -> bool:
 
 def _truthy(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_first_env(env_names: tuple[str, ...]) -> str:
+    for env_name in env_names:
+        env_value = os.getenv(env_name, "").strip()
+        if env_value:
+            return env_value
+    return ""

--- a/src/treehouse_lab/runtime_settings.py
+++ b/src/treehouse_lab/runtime_settings.py
@@ -20,6 +20,8 @@ DEFAULT_LLM_SETTINGS: dict[str, Any] = {
     "openai_api_key": "",
 }
 
+OLLAMA_API_KEY_ENV_VARS = ("OLLAMA_API_KEY", "OLLAMA_CLOUD_KEY", "VIOLAAMA_CLOUD_KEY")
+
 
 def llm_settings_path(project_root: Path) -> Path:
     return project_root / SETTINGS_DIRNAME / SETTINGS_FILENAME
@@ -49,11 +51,11 @@ def save_llm_settings(project_root: Path, payload: dict[str, Any]) -> Path:
 def effective_llm_settings(project_root: Path, defaults: dict[str, Any]) -> dict[str, Any]:
     saved = load_llm_settings(project_root)
     resolved = dict(DEFAULT_LLM_SETTINGS)
-    env_map = {
+    env_map: dict[str, str | tuple[str, ...]] = {
         "provider": "TREEHOUSE_LAB_LLM_PROVIDER",
         "model": "TREEHOUSE_LAB_LLM_MODEL",
         "ollama_base_url": "TREEHOUSE_LAB_OLLAMA_BASE_URL",
-        "ollama_api_key": "OLLAMA_API_KEY",
+        "ollama_api_key": OLLAMA_API_KEY_ENV_VARS,
         "agent_cli": "TREEHOUSE_LAB_AGENT_CLI",
         "openai_compatible_base_url": "TREEHOUSE_LAB_OPENAI_COMPATIBLE_BASE_URL",
         "openai_compatible_api_key": "TREEHOUSE_LAB_OPENAI_COMPATIBLE_API_KEY",
@@ -69,7 +71,11 @@ def effective_llm_settings(project_root: Path, defaults: dict[str, Any]) -> dict
             resolved[key] = str(saved_value).strip()
             continue
         env_name = env_map.get(key)
-        env_value = "" if env_name is None else os.getenv(env_name, "").strip()
+        env_value = ""
+        if isinstance(env_name, tuple):
+            env_value = _resolve_first_env(env_name)
+        elif isinstance(env_name, str):
+            env_value = os.getenv(env_name, "").strip()
         resolved[key] = env_value or default_value
 
     return resolved
@@ -92,3 +98,11 @@ def _normalize_settings(payload: dict[str, Any] | None) -> dict[str, Any]:
         }
     )
     return normalized
+
+
+def _resolve_first_env(env_names: tuple[str, ...]) -> str:
+    for env_name in env_names:
+        env_value = os.getenv(env_name, "").strip()
+        if env_value:
+            return env_value
+    return ""

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -167,3 +167,18 @@ def test_saved_settings_drive_advisor_without_env(
     assert response.json()["provider"] == "ollama"
     assert captured["url"] == "https://ollama.com/api/chat"
     assert captured["headers"]["Authorization"] == "Bearer rotated-key"
+
+
+def test_llm_settings_reads_ollama_cloud_key_alias_from_environment(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("TREEHOUSE_LAB_OLLAMA_BASE_URL", "https://ollama.com")
+    monkeypatch.setenv("VIOLAAMA_CLOUD_KEY", "alias-key")
+
+    response = client.get("/api/settings/llm")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ollama_base_url"] == "https://ollama.com"
+    assert payload["ollama_api_key"] == "alias-key"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 from treehouse_lab.datasets import (
+    _validate_stratified_split_feasibility,
     inspect_binary_target,
     inspect_classification_target,
     normalize_binary_target,
@@ -79,3 +80,22 @@ def test_inspect_classification_target_reports_multiclass_shape() -> None:
     assert profile["multiclass_supported"] is True
     assert profile["class_count"] == 3
     assert profile["class_counts"] == {"0": 1, "1": 1, "2": 2}
+
+
+def test_validate_stratified_split_feasibility_allows_balanced_data() -> None:
+    target = pd.Series([0] * 10 + [1] * 10, name="churned")
+
+    _validate_stratified_split_feasibility(target, test_size=0.2, validation_size=0.2)
+
+
+def test_validate_stratified_split_feasibility_rejects_underrepresented_class() -> None:
+    target = pd.Series([0] * 20 + [1], name="churned")
+
+    with pytest.raises(ValueError, match="Stratified split is not feasible"):
+        _validate_stratified_split_feasibility(target, test_size=0.2, validation_size=0.2)
+
+
+def test_validate_stratified_split_feasibility_allows_small_but_feasible_minority() -> None:
+    target = pd.Series([0] * 20 + [1] * 4, name="churned")
+
+    _validate_stratified_split_feasibility(target, test_size=0.2, validation_size=0.2)


### PR DESCRIPTION
### Motivation
- Allow using alternate environment variable names for Ollama cloud API keys so cloud-hosted Ollama can be selected more flexibly.  
- Prevent confusing runtime errors by validating that a requested stratified train/validation/test split is feasible given the class distribution before attempting the split.

### Description
- Add `OLLAMA_API_KEY_ENV_VARS` and update `_setting` and `effective_llm_settings` to consult multiple env var names for `ollama_api_key` and prefer the first present name.  
- Update user-facing Ollama error message to mention the full set of accepted env var names.  
- Add `_resolve_first_env` helper in both `llm.py` and `runtime_settings.py` to pick the first non-empty environment variable from a tuple.  
- Introduce `_validate_stratified_split_feasibility` and call it from `split_dataset` when `config.split.stratify` is true to pre-check that stratified splitting will succeed and emit a clearer `ValueError` on failure.

### Testing
- Added unit tests `test_llm_settings_reads_ollama_cloud_key_alias_from_environment` which verifies that `effective_llm_settings`/API returns the aliased Ollama key, and this test passed.  
- Added unit tests for `_validate_stratified_split_feasibility` covering balanced, underrepresented, and small-but-feasible minority scenarios, and these tests passed.  
- Ran the test suite including `tests/test_api_settings.py` and `tests/test_datasets.py` and all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e4740850833189adeedf47a42cd7)